### PR TITLE
fix: split stub and detail data for posts

### DIFF
--- a/src/actions/ensureDetails.js
+++ b/src/actions/ensureDetails.js
@@ -2,8 +2,8 @@ import * as fbApi from './fbApi';
 
 export default postId => 
   (dispatch, getState) => {
-    const post = getState().posts.items.find(post => post.id === postId);
-    if (!post || !post.detailsLoaded) {
+    const post = getState().posts.details.find(post => post.id === postId);
+    if (!post) {
       return dispatch(fbApi.getPostDetails(postId));
     }
     return Promise.resolve();

--- a/src/containers/PostDetails.jsx
+++ b/src/containers/PostDetails.jsx
@@ -26,9 +26,7 @@ const readableCreatedTime = createdTime => {
 class PostDetails extends Component {
   getVisual() {
     const { post } = this.props;
-    if (!post.detailsLoaded) {
-      return undefined;
-    } else if (post.type === 'video') {
+    if (post.type === 'video') {
       if (post.link) {
         return (
           <PostVideo iframeUrl={post.link} />
@@ -92,7 +90,7 @@ class PostDetails extends Component {
 
 const mapStateToProps = state => ({
   postId: state.view.detailId,
-  post: state.posts.selectedPost
+  post: state.posts.details.find((post) => post.id === state.view.detailId)
 });
 
 const mapDispatchToProps = {

--- a/src/containers/PostList.jsx
+++ b/src/containers/PostList.jsx
@@ -8,14 +8,14 @@ import PostSummary from '../components/PostSummary';
 
 class PostList extends Component {
   componentDidMount() {
-    if (!this.props.posts.items.length) {
+    if (!this.props.posts.stubs.length) {
       this.props.getPosts();
     }
   }
 
   render() {
     const {
-      posts: { items = [], cursors = {} },
+      posts: { stubs = [], cursors = {} },
       getPosts,
       selectPost
     } = this.props;
@@ -26,7 +26,7 @@ class PostList extends Component {
           Select a post from the list:
         </h2>
         <ul className="gm-postlist__list">
-          {items.map(post => (
+          {stubs.map(post => (
             <li className="gm-postlist__item" key={post.id}>
               <PostSummary
                 postData={post}

--- a/src/reducers/posts.js
+++ b/src/reducers/posts.js
@@ -1,6 +1,6 @@
 import { findIndex } from 'lodash';
 
-export default (state = { items: [] }, action) => {
+export default (state = { stubs: [], details: [] }, action) => {
   switch (action.type) {
     case 'GET_POSTS_REQUEST':
     case 'GET_POST_DETAILS_REQUEST':
@@ -23,35 +23,23 @@ export default (state = { items: [] }, action) => {
         ...state,
         fetching: false,
         error: false,
-        items: [...state.items, ...action.payload.data],
+        stubs: [...state.stubs, ...action.payload.data],
         cursors: action.payload.paging.cursors
       };
 
     case 'GET_POST_DETAILS_RESPONSE':
-      const postIndex = findIndex(state.items, { id: action.payload.id });
+      const postIndex = findIndex(state.details, { id: action.payload.id });
       return {
         ...state,
         fetching: false,
         error: false,
-        items:
+        details:
           postIndex > -1
-            ? // replace the existing post object with the incoming one (should be always the case)
-              immutableSplice(state.items, postIndex, 1, { detailsLoaded: true, ...action.payload })
-            : // backup scenario: add the incoming post object to the list
-              [...state.items,  { detailsLoaded: true, ...action.payload }]
+            ? // if a stub exists, replace it (should not happen)
+              immutableSplice(state.details, postIndex, 1, { detailsLoaded: true, ...action.payload })
+            : // else add it
+              [...state.details, action.payload ]
       };
-
-    case 'SWITCH_VIEW':
-      const viewName = action.payload.name;
-      const detailId = action.payload.detailId;
-      return viewName === 'postDetails' && detailId 
-        ?
-          {
-            ...state,
-            selectedPost: state.items.find(post => post.id === detailId)
-          }
-        :
-          state;
 
     default:
       return state;


### PR DESCRIPTION
prevent posts whose details were viewed via the URL form to show up on the chronological post list below.